### PR TITLE
Add bottom navigation bar UI with Home and Settings icons

### DIFF
--- a/frontend/lib/screens/home_screen.dart
+++ b/frontend/lib/screens/home_screen.dart
@@ -4,10 +4,65 @@ import 'package:frontend/theme/app_color_scheme.dart';
 import 'package:frontend/screens/route_detail_screen.dart';
 import 'package:frontend/screens/add_route_screen.dart';
 
-class HomeScreen extends StatelessWidget {
+class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
 
   @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  @override
+  int _selectedIndex = 0;
+
+  final List<Widget> _screens = [
+    // Tab 0: Home Screen route list
+    ListView.builder(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      itemCount: routes.length,
+      itemBuilder: (context, index) {
+        final route = routes[index];
+        return Card(
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+          color: AppColors.card,
+          elevation: 3,
+          margin: const EdgeInsets.symmetric(vertical: 8),
+          child: ListTile(
+            title: Text(
+              route.routeLabel,
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                color: AppColors.heading,
+              ),
+            ),
+            subtitle: Text(
+              '${route.sourceAddress} → ${route.destinationAddress}',
+            ),
+            leading: const Icon(Icons.route),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => RouteDetailScreen(route: route),
+                ),
+              );
+            },
+          ),
+        );
+      },
+    ),
+
+    // Tab 1: Settings screen
+    Center(
+      child: Text(
+        'Settings Page',
+        style: TextStyle(fontSize: 24, color: AppColors.heading),
+      ),
+    ),
+  ];
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: AppColors.background,
@@ -65,6 +120,8 @@ class HomeScreen extends StatelessWidget {
           );
         },
       ),
+
+      //FAB - Floating Action Button '+'
       floatingActionButton: FloatingActionButton(
         shape: const CircleBorder(),
         backgroundColor: AppColors.card,
@@ -88,6 +145,29 @@ class HomeScreen extends StatelessWidget {
             );
           }
         },
+      ),
+
+      // Bottom Navigation Bar
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _selectedIndex,
+        onTap: (int index) {
+          setState(() {
+            _selectedIndex = index;
+          });
+        },
+        backgroundColor: AppColors.card,
+        selectedItemColor: AppColors.heading,
+        unselectedItemColor: AppColors.heading.withAlpha(128),
+        iconSize: 28,
+        showSelectedLabels: false,
+        showUnselectedLabels: false,
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.settings),
+            label: 'Settings',
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
Implemented a bottom navigation bar on the Home screen with two icons — Home and Settings 

- Converted HomeScreen to StatefulWidget to manage selected tab state.

- Added BottomNavigationBar with two items:

  - Home (active by default)
  
  - Settings
